### PR TITLE
Fix pubsub setup and improve order service

### DIFF
--- a/Services/components/pubsub.yaml
+++ b/Services/components/pubsub.yaml
@@ -1,7 +1,7 @@
 apiVersion: dapr.io/v1alpha1
 kind: Component
 metadata:
-  name: orderpubsub
+  name: pubsub
 spec:
   type: pubsub.redis
   version: v1

--- a/Services/order/Program.cs
+++ b/Services/order/Program.cs
@@ -1,11 +1,33 @@
 var builder = WebApplication.CreateBuilder(args);
 builder.AddServiceDefaults();
 
+// Register Dapr client for publishing events
+builder.Services.AddDaprClient();
+
 var app = builder.Build();
 
 app.MapDefaultEndpoints();
 
-app.MapPost("/order", (Order order) => Results.Ok(order));
+app.MapPost("/order", async (Order order, Dapr.Client.DaprClient daprClient, ILogger<Program> logger) =>
+{
+    if (order.Id <= 0 || string.IsNullOrWhiteSpace(order.Product))
+    {
+        return Results.BadRequest("Invalid order");
+    }
+
+    try
+    {
+        await daprClient.PublishEventAsync("pubsub", "TestPubsub", order);
+        logger.LogInformation("Order {Id} published", order.Id);
+    }
+    catch (Exception ex)
+    {
+        logger.LogError(ex, "Failed to publish order {Id}", order.Id);
+        return Results.StatusCode(500);
+    }
+
+    return Results.Ok(order);
+});
 
 app.Run();
 


### PR DESCRIPTION
## Summary
- rename pubsub component to match code
- enhance order service with publishing and validation

## Testing
- `dotnet build Services/order/order.csproj -c Release` *(fails: unable to load the service index for https://api.nuget.org/v3/index.json)*